### PR TITLE
Remove fork reference in go code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/yesfeedme-archive/go-effects
 
 go 1.16
+
+require (
+	github.com/markdaws/go-timing v0.0.0-20170130172127-b53baafd482a
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/markdaws/go-timing v0.0.0-20170130172127-b53baafd482a h1:LN1LhGOZbQxtKyaSkREyx/IpDYqRfFzCKZq/tZbh+9Q=
+github.com/markdaws/go-timing v0.0.0-20170130172127-b53baafd482a/go.mod h1:HrBYz5V/fQozz575Ojme2qfHAdFxHOxpqRtv13V/RrE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/effects/effects_test.go
+++ b/pkg/effects/effects_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/markdaws/go-effects/pkg/effects"
 	"github.com/markdaws/go-timing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yesfeedme-archive/go-effects/pkg/effects"
 )
 
 const cabinPath = "../../test/cabin.jpg"


### PR DESCRIPTION
- Add dependencies to `go.mod` file.
- Replace forked path with new `yfm` path in golang code.